### PR TITLE
Module start and end times

### DIFF
--- a/examples/custom_examples/PythiaBrickTest.cc
+++ b/examples/custom_examples/PythiaBrickTest.cc
@@ -90,7 +90,26 @@ class HistTest : public JetScapeModuleBase
   private:
 };
 // ------------------------------------------
+class ClockTest : public JetScapeModuleBase
+{
+public:
 
+  ClockTest() : JetScapeModuleBase() {SetId("ClockTest");}
+
+  virtual void ExecTime(){
+    cout<< "ClockTest::ExecTime():============================ " <<     endl;
+    cout<< "ClockTest::ExecTime(): Current Main Clock Time = "<<GetMainClock()->GetCurrentTime() << endl;
+    cout<< "ClockTest::ExecTime(): Current Main Clock Detla T = "<<GetMainClock()->GetDeltaT() << endl;
+    if(UseModuleClock())cout<< "ClockTest::ExecTime(): Current Module Clock Time = "<<GetModuleClock()->GetCurrentTime() << endl;
+    if(UseModuleClock())cout<< "ClockTest::ExecTime(): Current Module Clock Detla T = "<<GetModuleClock()->GetDeltaT() << endl;
+    cout<< "ClockTest::ExecTime(): Current Module Start Time = "<< GetTStart() << endl;
+    cout<< "ClockTest::ExecTime(): Current Module End Time = "<< GetTEnd() << endl;
+    cout<< "ClockTest::ExecTime(): IsValidModuleTime?  "<< IsValidModuleTime() << endl;
+    cout<< "ClockTest::ExecTime():============================ " <<     endl;
+  }
+
+private:
+};
 // Forward declaration
 void Show();
 
@@ -122,7 +141,7 @@ int main(int argc, char** argv)
   //mClock->SetTimeRefFrameId("SpaceTime");
 
   // clocks here are defaulted for testing, clocks can costumized via inhererting from the MainClock/ModuleClock base classes ...
-  auto mClock = make_shared<MainClock>("SpaceTime",0,5,0.1); // JP: make consistent with reading from XML in init phase ...
+  auto mClock = make_shared<MainClock>("SpaceTime",1,5,0.1); // JP: make consistent with reading from XML in init phase ...
   auto mModuleClock = make_shared<ModuleClock>(); 
   mModuleClock->SetTimeRefFrameId("SpaceTime * 2");
 
@@ -149,8 +168,25 @@ int main(int argc, char** argv)
   jetscape->SetXMLUserFileName("../config/jetscape_user_test.xml");
   jetscape->SetId("primary");
   jetscape->AddMainClock(mClock);
+  jetscape->AddModuleClock(mModuleClock);
   jetscape->ClockInfo();
 
+  auto clockTest1 = make_shared<ClockTest>();
+  clockTest1->SetActive(false);
+
+  auto clockTest2 = make_shared<ClockTest>();
+  clockTest2->SetActive(false);
+  clockTest2->SetTimeRange(2.,3.5);
+  
+  auto clockTest3 = make_shared<ClockTest>();
+  clockTest3->SetActive(false);
+  clockTest3->SetTimeRange(2.,4.);
+  clockTest3->AddModuleClock(mModuleClock);
+  
+  jetscape->Add(clockTest1);
+  jetscape->Add(clockTest2);
+  jetscape->Add(clockTest3);
+  
   // Initial conditions and hydro
   //auto trento = make_shared<TrentoInitial>();
   auto trento = make_shared<InitialState>();

--- a/examples/custom_examples/PythiaBrickTest.cc
+++ b/examples/custom_examples/PythiaBrickTest.cc
@@ -141,7 +141,7 @@ int main(int argc, char** argv)
   //mClock->SetTimeRefFrameId("SpaceTime");
 
   // clocks here are defaulted for testing, clocks can costumized via inhererting from the MainClock/ModuleClock base classes ...
-  auto mClock = make_shared<MainClock>("SpaceTime",1,5,0.1); // JP: make consistent with reading from XML in init phase ...
+  auto mClock = make_shared<MainClock>("SpaceTime",-1,5,0.1); // JP: make consistent with reading from XML in init phase ...
   auto mModuleClock = make_shared<ModuleClock>(); 
   mModuleClock->SetTimeRefFrameId("SpaceTime * 2");
 
@@ -168,19 +168,19 @@ int main(int argc, char** argv)
   jetscape->SetXMLUserFileName("../config/jetscape_user_test.xml");
   jetscape->SetId("primary");
   jetscape->AddMainClock(mClock);
-  jetscape->AddModuleClock(mModuleClock);
   jetscape->ClockInfo();
 
   auto clockTest1 = make_shared<ClockTest>();
   clockTest1->SetActive(false);
+  clockTest1->SetTimeRange(-1,0);
 
   auto clockTest2 = make_shared<ClockTest>();
   clockTest2->SetActive(false);
-  clockTest2->SetTimeRange(2.,3.5);
+  //clockTest2->SetTimeRange(0,3.5);
   
   auto clockTest3 = make_shared<ClockTest>();
   clockTest3->SetActive(false);
-  clockTest3->SetTimeRange(2.,4.);
+  //clockTest3->SetTimeRange(0,4.);
   clockTest3->AddModuleClock(mModuleClock);
   
   jetscape->Add(clockTest1);

--- a/src/framework/JetScapeModuleBase.cc
+++ b/src/framework/JetScapeModuleBase.cc
@@ -33,7 +33,7 @@ int JetScapeModuleBase::current_event = 0;
    */
 JetScapeModuleBase::JetScapeModuleBase()
     : JetScapeTask(), xml_master_file_name(""), xml_user_file_name(""),
-      mt19937_generator_(nullptr), TimeModule() {}
+      mt19937_generator_(nullptr), TimeModule(0.,100.) {}
 
 // ---------------------------------------------------------------------------
 /** This is a destructor for the JetScapeModuleBase.                       
@@ -74,8 +74,7 @@ void JetScapeModuleBase::CalculateTimeTasks()
   for (auto it : tasks) {
     
     //cout<<it->GetId()<<" "<<it->GetActive()<<endl;
-
-    if (std::dynamic_pointer_cast<JetScapeModuleBase>(it) && !it->GetActive()) {
+    if (std::dynamic_pointer_cast<JetScapeModuleBase>(it) && !it->GetActive() && std::dynamic_pointer_cast<JetScapeModuleBase>(it)->IsValidModuleTime()) {
     VERBOSE(3) << "Calculate Time Step = " << it->GetId();
     //if (it->active_exec) 
       std::dynamic_pointer_cast<JetScapeModuleBase>(it)->CalculateTime();
@@ -87,19 +86,17 @@ void JetScapeModuleBase::CalculateTimeTasks()
 void JetScapeModuleBase::ExecTimeTasks()
 {
   if (ClockUsed()) {
-  auto tasks =  GetTaskList();
-  VERBOSE(3) << " : # Subtasks = " << tasks.size();
-  for (auto it : tasks) {
-    
-    //cout<<it->GetId()<<" "<<it->GetActive()<<endl;
-
-    if (std::dynamic_pointer_cast<JetScapeModuleBase>(it) && !it->GetActive()) {
-    VERBOSE(3) << "Execute Time Step = " << it->GetId();
-    //if (it->active_exec) 
-      std::dynamic_pointer_cast<JetScapeModuleBase>(it)->ExecTime();
+    auto tasks =  GetTaskList();
+    VERBOSE(3) << " : # Subtasks = " << tasks.size();
+    for (auto it : tasks) {     
+      //cout<<it->GetId()<<" "<<it->GetActive()<<endl;
+      if (std::dynamic_pointer_cast<JetScapeModuleBase>(it) && !it->GetActive() && std::dynamic_pointer_cast<JetScapeModuleBase>(it)->IsValidModuleTime()) {
+	VERBOSE(3) << "Execute Time Step = " << it->GetId();
+	//if (it->active_exec) 
+	std::dynamic_pointer_cast<JetScapeModuleBase>(it)->ExecTime();
+      }
     }
   }
- }
 }
 
 void JetScapeModuleBase::InitPerEventTasks()
@@ -135,7 +132,7 @@ void JetScapeModuleBase::FinishPerEventTasks()
       std::dynamic_pointer_cast<JetScapeModuleBase>(it)->FinishPerEvent();
     }
   }
- }
+  }
 }
 
 } // end namespace Jetscape

--- a/src/framework/JetScapeModuleBase.h
+++ b/src/framework/JetScapeModuleBase.h
@@ -97,7 +97,7 @@ public:
 
   //virtual void FinishPerEventTask() {}; // JP: see also in JetScapeTask ... is it really used or would this be the per event way ...
 
-  // --------------
+  // --------------                                                                                                                                                                                                   
 
   //JP: same can be done with variant if all datatypes are know
   //and put into the varaint definition --> elevated to framework like data types

--- a/src/framework/TimeModule.cc
+++ b/src/framework/TimeModule.cc
@@ -13,7 +13,12 @@ TimeModule::TimeModule()
 {
     mClock = nullptr;    
 }
-
+TimeModule::TimeModule(double t1, double t2)
+{
+  mClock = nullptr;
+  t0 = t1;
+  tn = t2;
+}
 void TimeModule::ClockInfo()
 {
     JSINFO<<"TimeModule::Info()";

--- a/src/framework/TimeModule.h
+++ b/src/framework/TimeModule.h
@@ -34,6 +34,9 @@ class TimeModule //: public JetScapeTask
 public:
 
     TimeModule();
+
+    TimeModule(double t1,double t2);
+
     virtual ~TimeModule() {};
 
     void ClockInfo();
@@ -53,11 +56,22 @@ public:
 
     double GetModuleDeltaT();
 
+    bool IsValidModuleTime() {if (GetModuleCurrentTime() >= t0 && GetModuleCurrentTime() < tn) return true; else return false;};  
+  
+    void SetTimeRange(double t1, double t2) {t0 = t1; tn = t2;};
+
+    double GetTStart() {return t0;};
+
+    double GetTEnd() {return tn;};
+  
 private:
 
     shared_ptr<ModuleClock> mClock;
     static shared_ptr<MainClock> mainClock;
 
+    double t0;// module start time; default is 0
+    double tn;// module end time; default is 100
+  
     static bool use_clock; //better in time based module base ...
 };
 


### PR DESCRIPTION
Start and stop times are added to TimeModule class. In JetScapeModuleBase, tasks which are executed on a time-step basis will only run when current module time (from main clock or module clock if applicable) is within the valid time range (using IsValidModuleTime() function). Default time ranges are from 0 to 100. Different times can be set per module by module->SetTimeRange(t1,t2). An example is added to PythiaBrickTest as ClockTest.