### PR TITLE
Proof of concept of SMASH afterburner module running with timesteps 

### DIFF
--- a/external_packages/smash/smash_config.yaml
+++ b/external_packages/smash/smash_config.yaml
@@ -4,7 +4,7 @@ Logging:
 General:
     Modus:  Afterburner   # Dummy, but some value has to be present
     Time_Step_Mode: Fixed
-    Delta_Time:    0.5
+    Delta_Time:    0.1
     End_Time:      100.0  # Reset from the JetScape xml config
     Randomseed:    -1     # Reset from the JetScape xml config
     Nevents:       1      # Dummy

--- a/src/afterburner/SmashWrapper.h
+++ b/src/afterburner/SmashWrapper.h
@@ -78,6 +78,10 @@ public:
   void InitTask();
   void ExecuteTask();
   void WriteTask(weak_ptr<JetScapeWriter> w);
+
+  void InitPerEvent() override;
+  void CalculateTimeTask() override;
+  void FinishPerEvent() override;
 };
 
 #endif // SMASHWRAPPER_H

--- a/src/framework/Afterburner.cc
+++ b/src/framework/Afterburner.cc
@@ -39,4 +39,9 @@ void Afterburner::Exec() {
   VERBOSE(2) << "Afterburner running: " << GetId() << " ...";
   ExecuteTask();
 }
+
+void Afterburner::CalculateTime() {
+  VERBOSE(2) << "Afterburner running for time: " << GetId() << " ...";
+  CalculateTimeTask();
+}
 } // end namespace Jetscape

--- a/src/framework/Afterburner.h
+++ b/src/framework/Afterburner.h
@@ -38,6 +38,7 @@ public:
 
   virtual void Init();
   virtual void Exec();
+  virtual void CalculateTime();
 
 protected:
   /// Pointer to particlization sampler, which provides initial hadrons


### PR DESCRIPTION
Instead of the whole event running, SMASH only runs its evolution synced 
with the main clock. Some small modfications to the SMASH source code 
are necessary for this to work. Also, choose smaller timestep in SMASH 
than for Jetscape clock in order for it to work propely at the moment.

Here is the patch that is necessary for SMASH in order for this to work: 
[smash-clock.patch.txt](https://github.com/jhputschke/J2XSCAPE-DEV/files/6460072/smash-clock.patch.txt)

Also, at least, the function call for the timestep evolution has still to be changed from `ExecTimeTask()` to `CalculateTimeTasks()`, which is the correct function to use when propagating the module.